### PR TITLE
Transparent lqip and avif support

### DIFF
--- a/extension.js
+++ b/extension.js
@@ -188,6 +188,18 @@ const generateImages = (uri, quality, type) => {
 				optimizeConvertWebp(input, output2xWebp, quality);
 				files[output2xWebp] = fs.statSync(output2xWebp).size;
 
+				if (avifSupport) {
+					const output2xAvif = input.replace(/.jpg$/, '.avif');
+					const output1xAvif = input.replace(/@2x.jpg$/, '.avif');
+					// Avif 1x
+					convertAvif(input, output1xAvif, width / 2);
+					files[output1xAvif] = fs.statSync(output1xAvif).size;
+
+					// Avif 2x
+					convertAvif(input, output2xAvif);
+					files[output2xAvif] = fs.statSync(output2xAvif).size;
+				}
+
 				// 1x jpg resize and optimize
 				resize(input, output1xJpg, width / 2);
 				optimizeJpg(output1xJpg, quality);

--- a/extension.js
+++ b/extension.js
@@ -115,7 +115,7 @@ const resize = (input, output, width) => {
 };
 
 const lqip = (input, output, resize = 64) => {
-	const command = 'convert ' + input + ' -resize ' + resize + 'x -blur 0x2 -quality 10 ' + output;
+	const command = 'convert ' + input + ' -adaptive-resize ' + resize + 'x -define webp:target-size=1024 -define webp:mode=6 -define webp:preprocessing=2 ' + output;
 
 	console.log(command);
 
@@ -165,7 +165,7 @@ const generateImages = (uri, quality, type) => {
 	quality = parseInt(quality);
 	const { lqipSize, avifSupport } = vscode.workspace.getConfiguration('responsive-images');
 
-	const lqipResize = lqipSize ? lqipSize : (lqipType !== 'jpg' ? 32 : 64);
+	const lqipResize = lqipSize || 64;
 
 	if (quality > 0 && quality <= 100) {
 		response.push('Target quality: ' + quality + '%');
@@ -307,7 +307,7 @@ const generateImages = (uri, quality, type) => {
 				);
 			}
 
-			vscode.window.showInformationMessage(response.join('\n'), { modal: true });
+			vscode.window.showInformationMessage(response.join('\n'), { modal: false });
 		} else {
 			vscode.window.showErrorMessage('Invalid image width');
 		}

--- a/package.json
+++ b/package.json
@@ -39,7 +39,7 @@
             "responsive-images.lqipType": {
                 "type": ["string", null],
                 "enum": ["jpg", "webp", "avif"],
-                "default": null,
+                "default": "webp",
                 "description": "Set lqip type [jpg, webp, avif] (default jpg)"
             },
             "responsive-images.avifSupport": {

--- a/package.json
+++ b/package.json
@@ -23,6 +23,31 @@
   ],
   "main": "./extension.js",
   "contributes": {
+    "configuration": {
+        "title": "Responsive Images",
+        "properties": {
+            "responsive-images.quality": {
+                "type": ["number", "null"],
+                "default": null,
+                "description": "Set optimization quality (default 90)"
+            },
+            "responsive-images.lqipSize": {
+                "type": ["number", "null"],
+                "default": null,
+                "description": "Set lqip size (default is 64)"
+            },
+            "responsive-images.lqipType": {
+                "type": ["string"],
+                "default": null,
+                "description": "Set lqip type [jpg, webp, avif] (default jpg)"
+            },
+            "responsive-images.avifSupport": {
+                "type": "boolean",
+                "default": false,
+                "description": "Enable avif convert"
+            }
+        }
+    },
     "commands": [
       {
         "command": "responsive-images.generateFrom2x",

--- a/package.json
+++ b/package.json
@@ -37,7 +37,8 @@
                 "description": "Set lqip size (default is 64)"
             },
             "responsive-images.lqipType": {
-                "type": ["string"],
+                "type": ["string", null],
+                "enum": ["jpg", "webp", "avif"],
                 "default": null,
                 "description": "Set lqip type [jpg, webp, avif] (default jpg)"
             },


### PR DESCRIPTION
- Added support for transparent `LQIP` image (`.webp` or `.avif`).
- Added `AVIF` support.
- Added settings for `settings.json`:
  - `"responsive-images.quality"` - {number} For optimization quality (default is `90`)
  - `"responsive-images.lqipType"` - {string: "jpg" | "webp" | "avif"}  LQIP image type (default is `"jpg"`)
  - `"responsive-images.lqipSize"` - {number}  LQIP width (default is `64`)
  - `"responsive-images.avifSupport"` - {boolean}  Enable AVIF convert (default is `false`)